### PR TITLE
Revert Order Merge! to Fail Silently

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -474,10 +474,10 @@ module Spree
                     }
         if current_line_item
           current_line_item.quantity += other_order_line_item.quantity
-          current_line_item.save!
+          current_line_item.save
         else
           other_order_line_item.order_id = self.id
-          other_order_line_item.save!
+          other_order_line_item.save
         end
       end
 


### PR DESCRIPTION
Trying this again on the right branch finally.

Filed issue: https://github.com/spree/spree/issues/5976

Not sure why other people haven't spoken up about this. I tested the other change to their .merge! method (the .detect stuff for comparison hooks), that was not the issue.

It seems like letting line_item.save fail silently was the previous way of handling this in spree 2.3.x so I reverted to that, although ideally I guess they would add logic around combining the desired quantities into the highest available amount? But I'm assuming most people with this error just want to buy an identical amount of something and just weren't logged in.